### PR TITLE
Make it explicit that JournalpostArkiv is Joark

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
@@ -33,7 +33,7 @@ class JoarkMottak(val env: Environment, private val journalpostArkiv: Journalpos
         @JvmStatic
         fun main(args: Array<String>) {
             val env = Environment()
-            val journalpostArkiv: JournalpostArkiv = JournalPostArkivHttpClient(
+            val journalpostArkiv: JournalpostArkiv = JournalpostArkivJoark(
                 env.journalfoerinngaaendeV1Url,
                 StsOidcClient(env.oicdStsUrl, env.username, env.password)
             )

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JournalpostArkivJoark.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JournalpostArkivJoark.kt
@@ -5,7 +5,7 @@ import com.github.kittinunf.fuel.httpGet
 import com.github.kittinunf.result.Result
 import no.nav.dagpenger.oidc.OidcClient
 
-class JournalPostArkivHttpClient(private val joarkBaseUrl: String, private val oidcClient: OidcClient) :
+class JournalpostArkivJoark(private val joarkBaseUrl: String, private val oidcClient: OidcClient) :
     JournalpostArkiv {
 
     val joarkUrl =
@@ -18,7 +18,7 @@ class JournalPostArkivHttpClient(private val joarkBaseUrl: String, private val o
             responseObject<Journalpost>()
         }
         return when (result) {
-            is Result.Failure -> throw JournalPostArkivException(
+            is Result.Failure -> throw JournalpostArkivException(
                 response.statusCode,
                 response.responseMessage,
                 result.getException()
@@ -30,5 +30,5 @@ class JournalPostArkivHttpClient(private val joarkBaseUrl: String, private val o
 
 fun String.toBearerToken() = "Bearer $this"
 
-class JournalPostArkivException(val statusCode: Int, override val message: String, override val cause: Throwable) :
+class JournalpostArkivException(val statusCode: Int, override val message: String, override val cause: Throwable) :
     RuntimeException(message, cause)

--- a/src/test/kotlin/no/nav/dagpenger/joark/mottak/JournalpostArkivJoarkTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/joark/mottak/JournalpostArkivJoarkTest.kt
@@ -15,7 +15,7 @@ import org.junit.Test
 import java.util.UUID
 import kotlin.test.assertEquals
 
-class JournalPostArkivHttpClientTest {
+class JournalpostArkivJoarkTest {
 
     @Rule
     @JvmField
@@ -28,7 +28,7 @@ class JournalPostArkivHttpClientTest {
     @Test
     fun `fetch JournalPost on 200 ok`() {
 
-        val body = JournalPostArkivHttpClientTest::class.java.getResource("/test-data/example-journalpost-payload.json")
+        val body = JournalpostArkivJoarkTest::class.java.getResource("/test-data/example-journalpost-payload.json")
             .readText()
         stubFor(
             get(urlEqualTo("/rest/journalfoerinngaaende/v1/journalposter/1"))
@@ -40,7 +40,7 @@ class JournalPostArkivHttpClientTest {
                 )
         )
 
-        val joarkClient = JournalPostArkivHttpClient(wireMockRule.url(""), DummyOidcClient())
+        val joarkClient = JournalpostArkivJoark(wireMockRule.url(""), DummyOidcClient())
         val journalPost = joarkClient.hentInngåendeJournalpost("1")
 
         assertEquals(journalPost.journalTilstand, JournalTilstand.ENDELIG)
@@ -76,7 +76,7 @@ class JournalPostArkivHttpClientTest {
         )
     }
 
-    @Test(expected = JournalPostArkivException::class)
+    @Test(expected = JournalpostArkivException::class)
     fun `fetch JournalPost on 200 ok but no content`() {
 
         val body = ""
@@ -90,11 +90,11 @@ class JournalPostArkivHttpClientTest {
                 )
         )
 
-        val joarkClient = JournalPostArkivHttpClient(wireMockRule.url(""), DummyOidcClient())
+        val joarkClient = JournalpostArkivJoark(wireMockRule.url(""), DummyOidcClient())
         joarkClient.hentInngåendeJournalpost("2")
     }
 
-    @Test(expected = JournalPostArkivException::class)
+    @Test(expected = JournalpostArkivException::class)
     fun `fetch JournalPost on 4xx errors`() {
 
         stubFor(
@@ -105,7 +105,7 @@ class JournalPostArkivHttpClientTest {
                 )
         )
 
-        val joarkClient = JournalPostArkivHttpClient(wireMockRule.url(""), DummyOidcClient())
+        val joarkClient = JournalpostArkivJoark(wireMockRule.url(""), DummyOidcClient())
         joarkClient.hentInngåendeJournalpost("-1")
     }
 }


### PR DESCRIPTION
The current name obscures the fact that the concrete implementation of JournalpostArkiv is Joark.

Changing the name makes it more explicit what we are talking to (vs how we are talking to it)