### PR TITLE
Filtrer pakker på NY_SØKNAD

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/HenvendelsesTypeMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/HenvendelsesTypeMapper.kt
@@ -34,15 +34,17 @@ object HenvendelsesTypeMapper {
         "NAV 04-01.03", // NAVe 04-01.03
         "NAVe 04-01.03",
         "NAV 04-01.04", // NAVe 04-01.04,
-        "NAVe 04-01.04"
+        "NAVe 04-01.04",
+        "NAV 04-06.08",
+        "NAV 04-06.09"
 
     )
 
     private val supportedTypes = mapOf(
         "NAV 04-01.03" to Henvendelsestype.NY_SØKNAD,
         "NAV 04-01.04" to Henvendelsestype.NY_SØKNAD,
-        "NAVe 04-01.03" to Henvendelsestype.NY_SØKNAD,
-        "NAVe 04-01.04" to Henvendelsestype.NY_SØKNAD
+        "NAVe 04-01.03" to Henvendelsestype.ETTERSENDING,
+        "NAVe 04-01.04" to Henvendelsestype.ETTERSENDING
     )
 
     fun getHenvendelsesType(navSkjemaId: String?): Henvendelsestype {
@@ -55,5 +57,7 @@ object HenvendelsesTypeMapper {
 }
 
 enum class Henvendelsestype {
-    NY_SØKNAD, ANNET
+    NY_SØKNAD,
+    ETTERSENDING,
+    ANNET
 }

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/HenvendelsesTypeMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/HenvendelsesTypeMapper.kt
@@ -43,8 +43,8 @@ object HenvendelsesTypeMapper {
     private val supportedTypes = mapOf(
         "NAV 04-01.03" to Henvendelsestype.NY_SØKNAD,
         "NAV 04-01.04" to Henvendelsestype.NY_SØKNAD,
-        "NAVe 04-01.03" to Henvendelsestype.ETTERSENDING,
-        "NAVe 04-01.04" to Henvendelsestype.ETTERSENDING
+        "NAVe 04-01.03" to Henvendelsestype.ETTERSENDELSE,
+        "NAVe 04-01.04" to Henvendelsestype.ETTERSENDELSE
     )
 
     fun getHenvendelsesType(navSkjemaId: String?): Henvendelsestype {
@@ -58,6 +58,6 @@ object HenvendelsesTypeMapper {
 
 enum class Henvendelsestype {
     NY_SØKNAD,
-    ETTERSENDING,
+    ETTERSENDELSE,
     ANNET
 }

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
@@ -95,6 +95,9 @@ class JoarkMottak(
                     }
                 }
             }
+            .filter { _, packet ->
+                packet.getBoolean(PacketKeys.NY_SØKNAD)
+            }
             .selectKey { _, value -> value.getStringValue(PacketKeys.JOURNALPOST_ID) }
             .toTopic(config.kafka.dagpengerJournalpostTopic)
 


### PR DESCRIPTION
Endret noen skjemaider til å mappes til ettersending. 

For øyeblikket er vi kun interessert i pakker som mappes til ny søknad, dermed filtrerer vi vekk resten.