### PR TITLE
Legger på verdier til oppdatering av journalpost

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
@@ -35,6 +35,7 @@ private val jpCounter = Counter
     .register()
 
 internal object PacketKeys {
+    const val AVSENDER_NAVN: String = "avsenderNavn"
     const val DATO_REGISTRERT: String = "datoRegistrert"
     const val DOKUMENT_TITLER: String = "dokumentTitler"
     const val NY_SØKNAD: String = "nySøknad"
@@ -102,6 +103,7 @@ class JoarkMottak(
                             this.putValue(PacketKeys.AKTØR_ID, it.aktoerId)
                             this.putValue(PacketKeys.NATURLIG_IDENT, it.naturligIdent)
                             this.putValue(PacketKeys.BEHANDLENDE_ENHETER, it.behandlendeEnheter)
+                            this.putValue(PacketKeys.AVSENDER_NAVN, it.navn)
                         }
                     } else {
                         logger.warn { "Journalpost er ikke tilknyttet bruker? " }

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
@@ -35,6 +35,7 @@ private val jpCounter = Counter
     .register()
 
 internal object PacketKeys {
+    const val DOKUMENTER: String = "dokumenter"
     const val AVSENDER_NAVN: String = "avsenderNavn"
     const val DATO_REGISTRERT: String = "datoRegistrert"
     const val DOKUMENT_TITLER: String = "dokumentTitler"
@@ -52,7 +53,7 @@ class JoarkMottak(
     val personOppslag: PersonOppslag
 ) : Service() {
     override val healthChecks: List<HealthCheck> =
-            listOf(journalpostArkiv as HealthCheck, personOppslag as HealthCheck)
+        listOf(journalpostArkiv as HealthCheck, personOppslag as HealthCheck)
 
     override val SERVICE_APP_ID =
         "dagpenger-joark-mottak" // NB: also used as group.id for the consumer group - do not change!
@@ -89,6 +90,9 @@ class JoarkMottak(
                     this.putValue(PacketKeys.JOURNALPOST_ID, journalpost.journalpostId)
                     this.putValue(PacketKeys.HOVEDSKJEMA_ID, journalpost.dokumenter.first().brevkode ?: "ukjent")
                     this.putValue(PacketKeys.DOKUMENT_TITLER, journalpost.dokumenter.map { it.tittel })
+                    this.putValue(
+                        PacketKeys.DOKUMENTER, journalpost.dokumenter.map { Pair(it.tittel, it.dokumentInfoId) })
+
                     this.putValue(
                         PacketKeys.NY_SØKNAD,
                         journalpost.mapToHenvendelsesType() == Henvendelsestype.NY_SØKNAD

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottak.kt
@@ -91,7 +91,8 @@ class JoarkMottak(
                     this.putValue(PacketKeys.HOVEDSKJEMA_ID, journalpost.dokumenter.first().brevkode ?: "ukjent")
                     this.putValue(PacketKeys.DOKUMENT_TITLER, journalpost.dokumenter.map { it.tittel })
                     this.putValue(
-                        PacketKeys.DOKUMENTER, journalpost.dokumenter.map { Pair(it.tittel, it.dokumentInfoId) })
+                        PacketKeys.DOKUMENTER, journalpost.dokumenter
+                    )
 
                     this.putValue(
                         PacketKeys.NY_SØKNAD,

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/Person.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/Person.kt
@@ -5,6 +5,7 @@ data class GraphQlPersonResponse(val data: Data, val errors: List<String>?) {
 }
 
 data class Person(
+    val navn: String,
     val aktoerId: String,
     val naturligIdent: String,
     val behandlendeEnheter: List<BehandlendeEnhet>

--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/PersonOppslag.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/PersonOppslag.kt
@@ -58,6 +58,7 @@ internal data class PersonQuery(val id: String, val idType: IdType) : GraphqlQue
     query = """ 
             query {
                 person(id: "$id", idType: ${idType.name}) {
+                    navn
                     aktoerId
                     naturligIdent
                     behandlendeEnheter {

--- a/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakComponentTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakComponentTest.kt
@@ -57,6 +57,7 @@ class JoarkMottakComponentTest {
             embeddedEnvironment.start()
             joarkMottak.start()
             every { personOppslagMock.hentPerson(any(), any()) } returns Person(
+                navn = "Pelle",
                 aktoerId = "1111",
                 naturligIdent = "1234",
                 behandlendeEnheter = listOf(BehandlendeEnhet(enhetId = "abc", enhetNavn = "NAV Enhet"))

--- a/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakTopologyTest.kt
@@ -25,6 +25,7 @@ class JoarkMottakTopologyTest {
         @JvmStatic
         fun setUp() {
             every { personOppslagMock.hentPerson(any(), any()) } returns Person(
+                navn = "Proffen",
                 aktoerId = "1111",
                 naturligIdent = "1234",
                 behandlendeEnheter = listOf(BehandlendeEnhet(enhetId = "abc", enhetNavn = "NAV Enhet"))


### PR DESCRIPTION
Nå har vi lagt på:
* listen av dokumenter, som inneholder tittel, dokumentInfoId og brevkode.
* fullt navn på bruker (avsender)

Vi har ikke lagt på journalpost.innhold (altså tittlelen på journalposten). Denne skal være lik som hoveddokumentets tittel, og kan dermed hentes fra første dokument i listen på pakken (første dokument er hoveddokument)