### PR TITLE
Refactor

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/joark/mottak/PacketCreator.kt
+++ b/src/main/kotlin/no/nav/dagpenger/joark/mottak/PacketCreator.kt
@@ -1,0 +1,50 @@
+package no.nav.dagpenger.joark.mottak
+
+import mu.KotlinLogging
+import no.finn.unleash.Unleash
+import no.nav.dagpenger.events.Packet
+
+private val logger = KotlinLogging.logger {}
+class PacketCreator(
+    val personOppslag: PersonOppslag,
+    val unleash: Unleash
+) {
+    fun createPacket(journalpost: Journalpost) = Packet().apply {
+        this.putValue(PacketKeys.TOGGLE_BEHANDLE_NY_SØKNAD, unleash.isEnabled("dp.innlop.behandleNySoknad"))
+
+        this.putValue(PacketKeys.JOURNALPOST_ID, journalpost.journalpostId)
+        this.putValue(PacketKeys.HOVEDSKJEMA_ID, journalpost.dokumenter.first().brevkode ?: "ukjent")
+        this.putValue(
+            PacketKeys.DOKUMENTER, journalpost.dokumenter
+        )
+
+        this.putValue(
+            PacketKeys.NY_SØKNAD,
+            journalpost.mapToHenvendelsesType() == Henvendelsestype.NY_SØKNAD
+        )
+
+        journalpost.relevanteDatoer.find { it.datotype == Datotype.DATO_REGISTRERT }?.let {
+            this.putValue(PacketKeys.DATO_REGISTRERT, it.dato)
+        }
+
+        if (null != journalpost.bruker) {
+            personOppslag.hentPerson(journalpost.bruker.id, journalpost.bruker.type).let {
+                this.putValue(PacketKeys.AKTØR_ID, it.aktoerId)
+                this.putValue(PacketKeys.NATURLIG_IDENT, it.naturligIdent)
+                this.putValue(PacketKeys.AVSENDER_NAVN, it.navn)
+                this.putValue(PacketKeys.BEHANDLENDE_ENHET, behandlendeEnhetFrom(it.diskresjonskode, journalpost.dokumenter.first().brevkode ?: "ukjent"))
+            }
+        } else {
+            logger.warn { "Journalpost er ikke tilknyttet bruker?" }
+        }
+    }
+
+    private fun behandlendeEnhetFrom(diskresjonskode: String?, brevkode: String): String {
+        return when {
+            diskresjonskode == "SPSF" -> "2103"
+            brevkode == "NAV 04-01.03" -> "4450"
+            brevkode == "NAV 04-01.04" -> "4455"
+            else -> throw UnsupportedBehandlendeEnhetException("Cannot find behandlende enhet for brevkode $brevkode")
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/joark/mottak/CreatePacketTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/joark/mottak/CreatePacketTest.kt
@@ -1,0 +1,163 @@
+package no.nav.dagpenger.joark.mottak
+
+import com.squareup.moshi.Types
+import io.kotlintest.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.finn.unleash.FakeUnleash
+import no.nav.dagpenger.events.Packet
+import no.nav.dagpenger.events.moshiInstance
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+
+class CreatePacketTest {
+
+    companion object {
+        val personOppslagMock = mockk<PersonOppslag>()
+
+        @BeforeAll
+        @JvmStatic
+        fun setUp() {
+            every { personOppslagMock.hentPerson(any(), any()) } returns Person(
+                navn = "Proffen",
+                aktoerId = "1111",
+                naturligIdent = "1234",
+                diskresjonskode = null
+            )
+        }
+    }
+
+    private fun dummyJournalpost(
+        journalstatus: Journalstatus? = null,
+        journalpostId: String = "12345",
+        bruker: Bruker? = Bruker(BrukerType.AKTOERID, "123456789"),
+        tittel: String? = null,
+        datoOpprettet: String? = null,
+        kanal: String? = null,
+        kanalnavn: String? = null,
+        journalforendeEnhet: String? = null,
+        relevanteDatoer: List<RelevantDato> = emptyList(),
+        dokumenter: List<DokumentInfo> = listOf(DokumentInfo("tittel", "infoId", "NAV 04-01.03"))
+    ) = Journalpost(
+        journalstatus = journalstatus,
+        journalpostId = journalpostId,
+        bruker = bruker,
+        tittel = tittel,
+        datoOpprettet = datoOpprettet,
+        kanal = kanal,
+        kanalnavn = kanalnavn,
+        journalforendeEnhet = journalforendeEnhet,
+        relevanteDatoer = relevanteDatoer,
+        dokumenter = dokumenter
+    )
+
+    @Test
+    fun `skal hente og legge brukerinfo på packet`() {
+        val journalpost = dummyJournalpost(
+            bruker = Bruker(BrukerType.AKTOERID, "1111"),
+            dokumenter = listOf(DokumentInfo("tittel", "infoId", "NAV 04-01.03"))
+        )
+
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val packet = packetCreator.createPacket(journalpost)
+
+        verify { personOppslagMock.hentPerson("1111", BrukerType.AKTOERID) }
+
+        packet.getStringValue("aktørId") shouldBe "1111"
+        packet.getStringValue("naturligIdent") shouldBe "1234"
+        packet.getStringValue("avsenderNavn") shouldBe "Proffen"
+        packet.getStringValue("behandlendeEnhet") shouldBe "4450"
+    }
+
+    @Test
+    fun `skal gi hovedskjema`() {
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+
+        val journalpost = dummyJournalpost(
+            dokumenter = listOf(DokumentInfo("tittel", "infoId", "NAV 04-01.04"))
+        )
+        val packet = packetCreator.createPacket(journalpost)
+
+        packet.getStringValue("hovedskjemaId") shouldBe "NAV 04-01.04"
+        packet.getBoolean("nySøknad") shouldBe true
+    }
+
+    @Test
+    fun `skal legge dokumentliste på pakken i JSON-format`() {
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+
+        val journalpost = dummyJournalpost(
+            dokumenter = listOf(DokumentInfo("Søknad", "infoId", "NAV 04-01.04"))
+        )
+        val packet = packetCreator.createPacket(journalpost)
+
+        val adapter = moshiInstance.adapter<List<DokumentInfo>>(
+            Types.newParameterizedType(
+                List::class.java,
+                DokumentInfo::class.java
+            )
+        )
+
+        val dokumentListe = Packet(packet.toJson()!!).getObjectValue("dokumenter") { adapter.fromJsonValue(it)!! }
+        dokumentListe.size shouldBe 1
+        dokumentListe.first().tittel shouldBe "Søknad"
+    }
+
+    @Test
+    fun `skal legge behandlings-toggle med verdi true på packet når toggle er på `() {
+        val unleash = FakeUnleash()
+        val packetCreator = PacketCreator(personOppslagMock, unleash)
+
+        val journalpost = dummyJournalpost()
+
+        unleash.disable("dp.innlop.behandleNySoknad")
+        val disabledPacket = packetCreator.createPacket(journalpost)
+        disabledPacket.getBoolean("toggleBehandleNySøknad") shouldBe false
+
+        unleash.enable("dp.innlop.behandleNySoknad")
+        val enabledPacket = packetCreator.createPacket(journalpost)
+        enabledPacket.getBoolean("toggleBehandleNySøknad") shouldBe true
+    }
+
+    @Test
+    fun `skal få riktig behandlende enhet ved kode 6`() {
+        val personOppslagMedDiskresjonskode = mockk<PersonOppslag>()
+
+        every { personOppslagMedDiskresjonskode.hentPerson(any(), any()) } returns Person(
+            navn = "Proffen",
+            aktoerId = "1111",
+            naturligIdent = "1234",
+            diskresjonskode = "SPSF"
+        )
+
+        val packetCreator = PacketCreator(personOppslagMedDiskresjonskode, FakeUnleash())
+        val packet = packetCreator.createPacket(dummyJournalpost())
+
+        packet.getStringValue("behandlendeEnhet") shouldBe "2103"
+    }
+
+    @Test
+    fun `nye søknader (ikke permitering) skal havne på benk 4450`() {
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+
+        val journalpost = dummyJournalpost(
+            dokumenter = listOf(DokumentInfo(tittel = "Søknad", dokumentInfoId = "9", brevkode = "NAV 04-01.03"))
+        )
+        val packet = packetCreator.createPacket(journalpost)
+
+        packet.getStringValue("behandlendeEnhet") shouldBe "4450"
+    }
+
+    @Test
+    fun `nye søknader ved permitering skal havne på benk 4455`() {
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+
+        val journalpost = dummyJournalpost(
+            dokumenter = listOf(DokumentInfo(tittel = "Søknad", dokumentInfoId = "9", brevkode = "NAV 04-01.04"))
+        )
+        val packet = packetCreator.createPacket(journalpost)
+
+        packet.getStringValue("behandlendeEnhet") shouldBe "4455"
+    }
+}

--- a/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakTopologyTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/joark/mottak/JoarkMottakTopologyTest.kt
@@ -40,7 +40,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `Skal prosessere inkomne journalposter med tema DAG og hendelses type MidlertidigJournalført `() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -55,7 +56,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `Skal telle antall mottatte journalposter som kan behandles`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -70,7 +72,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `Skal ikke prosessere journalposter med andre temaer en DAG`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val inputRecord = factory.create(lagJoarkHendelse(123, "ANNET", "MidlertidigJournalført"))
             topologyTestDriver.pipeInput(inputRecord)
@@ -83,7 +86,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `Skal ikke prosessere inkomne journalposter med tema DAG og hendelses type Ferdigstilt `() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "Ferdigstilt"))
@@ -97,7 +101,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `skal mappe aktørid riktig`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -112,7 +117,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `skal gi hovedskjema`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -128,7 +134,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `skal legge dokumentliste på pakken i JSON-format`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -152,7 +159,8 @@ class JoarkMottakTopologyTest {
 
     @Test
     fun `skal legge navn på pakken`() {
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
@@ -183,7 +191,8 @@ class JoarkMottakTopologyTest {
             dokumenter = listOf(DokumentInfo(dokumentInfoId = "9", brevkode = "NAVe 04-01.04", tittel = "søknad"))
         )
 
-        val joarkMottak = JoarkMottak(configuration, journalpostarkiv, personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, journalpostarkiv, packetCreator)
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val inputRecord = factory.create(lagJoarkHendelse(journalpostId, "DAG", "MidlertidigJournalført"))
             topologyTestDriver.pipeInput(inputRecord)
@@ -197,7 +206,8 @@ class JoarkMottakTopologyTest {
     @Test
     fun `skal legge behandlings-toggle med verdi true på packet når toggle er på `() {
         val unleash = FakeUnleash()
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMock, unleash)
+        val packetCreator = PacketCreator(personOppslagMock, unleash)
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
 
         unleash.disable("dp.innlop.behandleNySoknad")
 
@@ -280,7 +290,8 @@ class JoarkMottakTopologyTest {
             diskresjonskode = "SPSF"
         )
 
-        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), personOppslagMedDiskresjonskode, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMedDiskresjonskode, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
 
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
@@ -313,7 +324,8 @@ class JoarkMottakTopologyTest {
             dokumenter = listOf(DokumentInfo(tittel = "Søknad", dokumentInfoId = "9", brevkode = "NAV 04-01.03"))
         )
 
-        val joarkMottak = JoarkMottak(configuration, journalpostArkivMock, personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, journalpostArkivMock, packetCreator)
 
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123
@@ -346,7 +358,8 @@ class JoarkMottakTopologyTest {
             dokumenter = listOf(DokumentInfo(tittel = "Søknad", dokumentInfoId = "9", brevkode = "NAV 04-01.04"))
         )
 
-        val joarkMottak = JoarkMottak(configuration, journalpostArkivMock, personOppslagMock, FakeUnleash())
+        val packetCreator = PacketCreator(personOppslagMock, FakeUnleash())
+        val joarkMottak = JoarkMottak(configuration, DummyJournalpostArkiv(), packetCreator)
 
         TopologyTestDriver(joarkMottak.buildTopology(), streamProperties).use { topologyTestDriver ->
             val journalpostId: Long = 123


### PR DESCRIPTION
Flyttet pakke-opprettelse til egen klasse, og forenklet / flyttet tester. Brukt wiremock i component test, i stedet for å mocke adapter.